### PR TITLE
Fix "Before you begin" packages list

### DIFF
--- a/tasty_bytes_snowpark_101.ipynb
+++ b/tasty_bytes_snowpark_101.ipynb
@@ -48,7 +48,7 @@
     "You will be running this as a Snowflake Notebook, so you will need to add the following packages in the Packages drop-down menu in the upper right corner of the UI:\n",
     "- matplotlib \n",
     "- plotly\n",
-    "- snowpark-ml-python"
+    "- snowflake-ml-python"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo in Packages section of markdown (was snowpark-ml-python, now snowflake-ml-python)